### PR TITLE
extend regex to match multiple protocols

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -44,7 +44,7 @@ do
         mkdir db/$n1-$n2
         timeout 30 python3 $linkf -d -i $i -o cli > js/$n1-$n2/raw.txt
 
-        jslinks=$(cat js/$n1-$n2/raw.txt | grep -oaEi "https?://[^\"\\'> ]+" | grep '\.js' | grep "$n1" | sort -u)
+        jslinks=$(cat js/$n1-$n2/raw.txt | grep -oaEi "(https|http|wss|ws?)?:?//[^\"\\'> ]+" | grep '\.js' | grep "$n1" | sort -u)
 
         if [[ ! -z $jslinks ]]
         then


### PR DESCRIPTION
This modified regexp will match URLs starting with http/https/ws/wss protocols, it also matches protocol relative URLs